### PR TITLE
feat: fix keyFrame not found for last chunk

### DIFF
--- a/src/ReplayManager.ts
+++ b/src/ReplayManager.ts
@@ -146,19 +146,14 @@ export class ReplayManager {
     }
 
     private findKeyFrameByChunkId(metadata: IMetaData, chunkId: number): number {
+        let keyFrameId = 1;
         for (let keyFrameInfo of metadata.pendingAvailableKeyFrameInfo) {
-            if (keyFrameInfo.nextChunkId === chunkId) {
-                return keyFrameInfo.keyFrameId;
+            if (keyFrameInfo.nextChunkId > chunkId) {
+                break;
             }
+            keyFrameId = keyFrameInfo.keyFrameId;
         }
-
-        for (let keyFrameInfo of metadata.pendingAvailableKeyFrameInfo) {
-            if (keyFrameInfo.nextChunkId === chunkId - 1) {
-                return keyFrameInfo.keyFrameId;
-            }
-        }
-
-        throw new Error("keyframe not found for chunkId: " + chunkId);
+        return keyFrameId;
     }
 
     private async testGameExists(gameId: string): Promise<void> {


### PR DESCRIPTION
If the last chunkId is 56, but the last keyFrameId is 27 for example, the server will not find the corresponding keyFrame.

KeyFrames are supposed to be emitted for every two chunks, thus keyFrame 27 is for chunk 54 `(27*2)` and 55 `(27*2+1)`

For the last chunk of the game, a keyFrame may not be emitted if it has an odd chunkId. Thus we should use the closest keyFrame in the past.